### PR TITLE
Add MAKE-COMPRESSING-STREAM

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 ;;;
-;;; Copyright (c) 2007 Zachary Beane, All Rights Reserved
+;;; Copyright (c) 2007-2021 Zachary Beane and contributors, All Rights Reserved
 ;;;
 ;;; Redistribution and use in source and binary forms, with or without
 ;;; modification, are permitted provided that the following conditions

--- a/doc/COPYING.txt
+++ b/doc/COPYING.txt
@@ -1,5 +1,5 @@
 ;;;
-;;; Copyright (c) 2007 Zachary Beane, All Rights Reserved
+;;; Copyright (c) 2007-2021 Zachary Beane and contributors, All Rights Reserved
 ;;;
 ;;; Redistribution and use in source and binary forms, with or without
 ;;; modification, are permitted provided that the following conditions

--- a/doc/index.html
+++ b/doc/index.html
@@ -86,6 +86,14 @@ The latest version is 2.0.9, released on July 18th, 2013.
 	  <li> <a href='#gzip-file'><tt>gzip-file</tt></a>
 	  <li> <a href='#compress-data'><tt>compress-data</tt></a>
 	</ul>
+
+      <li> <a href='#sect-gray-streams'>Gray Streams</a>
+
+    <ul>
+      <li> <a href='#make-compressing-stream'><tt>make-compressing-stream</tt></a>
+      <li> <a href='#stream-closed-error'><tt>stream-closed-error</tt></a>
+    </ul>
+
     </ul>
 
   <li> <a href='#sect-references'>References</a>
@@ -449,6 +457,30 @@ compressor-designator initargs)</tt>.
 </pre>
 </blockquote>
 
+<a name='sect-gray-streams'><h4>Gray Streams</h4></a>
+
+<p> Salza2 includes support for creating a Gray stream that wraps another
+  stream and transparently compresses the data written to it.
+
+<p><a name='make-compressing-stream'>[Function]</a><br>
+<b>make-compressing-stream</b> <i>compressor-type</i> <i>stream</i>
+=> <i>compressing-stream</i>
+
+<blockquote>
+Return a <i>compressing-stream</i> that transparently compresses its input
+and writes it to <i>stream</i>. <i>compressor-type</i> is a symbol naming the
+compressor class to use.
+
+<p>Closing the returned <i>compressing-stream</i> merely finalizes the compression
+and does not close <i>stream</i>.
+</blockquote>
+
+<p><a name='stream-closed-error'>[Condition]</a><br>
+<b>stream-closed-error</b> <i>stream-error</i>
+
+<blockquote>
+Signaled when attempting to write to a closed <i>compressing-stream</i>.
+</blockquote>
 
 <a name='sect-references'><h3>References</h3></a>
 

--- a/package.lisp
+++ b/package.lisp
@@ -58,4 +58,7 @@
    #:make-stream-output-callback
    #:gzip-stream
    #:gzip-file
-   #:compress-data))
+   #:compress-data
+   ;; stream
+   #:make-compressing-stream
+   #:stream-closed-error))

--- a/salza2.asd
+++ b/salza2.asd
@@ -33,6 +33,7 @@
   :description "Create compressed data in the ZLIB, DEFLATE, or GZIP
   data formats"
   :depends-on ("trivial-gray-streams")
+  :in-order-to ((asdf:test-op (asdf:test-op "salza2/test")))
   :components ((:file "package")
                (:file "reset"
                       :depends-on ("package"))
@@ -94,3 +95,19 @@
                                    "gzip"))
                (:file "stream"
                       :depends-on ("package"))))
+
+(asdf:defsystem #:salza2/test
+  :author "Zachary Beane <xach@xach.com>"
+  :license "BSD"
+  :version "2.0.9"
+  :description "Tests for Salza2 system"
+  :depends-on ("salza2" "parachute" "flexi-streams" "chipz")
+  :perform (asdf:test-op (op c)
+                         (unless (eql :passed
+                                      (uiop:symbol-call
+                                       :parachute :status
+                                       (uiop:symbol-call :parachute :test :salza2-test)))
+                           (error "Tests failed")))
+  :pathname "test/"
+  :components ((:file "package")
+               (:file "stream" :depends-on ("package"))))

--- a/salza2.asd
+++ b/salza2.asd
@@ -32,6 +32,7 @@
   :version "2.0.9"
   :description "Create compressed data in the ZLIB, DEFLATE, or GZIP
   data formats"
+  :depends-on ("trivial-gray-streams")
   :components ((:file "package")
                (:file "reset"
                       :depends-on ("package"))
@@ -90,4 +91,6 @@
                       :depends-on ("package"
                                    "compressor"
                                    "zlib"
-                                   "gzip"))))
+                                   "gzip"))
+               (:file "stream"
+                      :depends-on ("package"))))

--- a/stream.lisp
+++ b/stream.lisp
@@ -1,0 +1,94 @@
+;;;
+;;; Copyright (c) 2021 Eric Timmons, All Rights Reserved
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+
+(in-package #:salza2)
+
+(define-condition stream-closed-error (stream-error)
+  ()
+  (:documentation "Signaled when attempting to write to a closed COMPRESSING-STREAM.")
+  (:report (lambda (condition stream)
+             (format stream "Stream ~S is closed" (stream-error-stream condition)))))
+
+(defclass compressing-stream (trivial-gray-streams:fundamental-binary-output-stream)
+  ((openp
+    :initform t
+    :accessor openp)
+   (compressor
+    :initarg :compressor
+    :accessor compressor))
+  (:documentation
+   "A gray stream that transparently compresses its input and writes the
+compressed data to another stream."))
+
+(defun make-compressing-stream (compressor-type stream)
+  "Return a COMPRESSING-STREAM that transparently compresses its input and
+writes it to STREAM. COMPRESSOR-TYPE is a symbol naming the compressor class to
+use.
+
+Closing the returned COMPRESSING-STREAM merely finalizes the compression and
+does not close STREAM."
+  (make-instance
+   'compressing-stream
+   :compressor (make-instance
+                compressor-type
+                :callback (make-stream-output-callback stream))))
+
+
+(defmethod trivial-gray-streams:stream-write-byte ((stream compressing-stream) byte)
+  (unless (openp stream)
+    (error 'stream-closed-error :stream stream))
+  (compress-octet byte (compressor stream))
+  byte)
+
+(defmethod trivial-gray-streams:stream-write-sequence ((stream compressing-stream) sequence start end &key)
+  (unless (openp stream)
+    (error 'stream-closed-error :stream stream))
+  (let ((vector (if (typep sequence 'vector)
+                    sequence
+                    (coerce sequence 'vector))))
+    (compress-octet-vector vector (compressor stream) :start start :end end))
+  sequence)
+
+(defmethod trivial-gray-streams:stream-file-position ((stream compressing-stream))
+  "Does not keep track of position in the stream."
+  nil)
+
+(defmethod (setf trivial-gray-streams:stream-file-position) (newval (stream compressing-stream))
+  "Unable to seek within the stream."
+  (declare (ignore newval))
+  nil)
+
+(defmethod stream-element-type ((stream compressing-stream))
+  '(unsigned-byte 8))
+
+(defmethod close ((stream compressing-stream) &key abort)
+  (declare (ignore abort))
+  (when (openp stream)
+    (finish-compression (compressor stream))
+    (setf (openp stream) nil)
+    t))

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,0 +1,31 @@
+;;;
+;;; Copyright (c) 2021 Eric Timmons, All Rights Reserved
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+
+(defpackage #:salza2-test
+  (:use #:cl
+        #:parachute))

--- a/test/stream.lisp
+++ b/test/stream.lisp
@@ -1,0 +1,59 @@
+;;;
+;;; Copyright (c) 2021 Eric Timmons, All Rights Reserved
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+
+(in-package #:salza2-test)
+
+(defparameter *data-size* (* 10 1024))
+
+(define-test compressing-stream
+  "Test the compressing stream by round tripping random data through salza2 and
+then chipz."
+  (let ((data (make-array *data-size* :element-type '(unsigned-byte 8)
+                                      :initial-contents (loop :repeat *data-size*
+                                                              :collect (random 256))))
+        (round-trip-data (make-array *data-size* :element-type '(unsigned-byte 8)
+                                                 :initial-element 0))
+        compressed-data)
+    (setf compressed-data
+          (flexi-streams:with-output-to-sequence (wrapped-stream)
+            (with-open-stream
+                (out-stream (salza2:make-compressing-stream 'salza2:gzip-compressor wrapped-stream))
+              (write-sequence data out-stream))))
+    (flexi-streams:with-input-from-sequence (wrapped-stream compressed-data)
+      (with-open-stream
+          (in-stream (chipz:make-decompressing-stream 'chipz:gzip wrapped-stream))
+        (read-sequence round-trip-data in-stream)
+        (is eql :eof (read-byte in-stream nil :eof))))
+    (is equalp data round-trip-data)))
+
+(define-test compressing-stream-closed-error
+  (flexi-streams:with-output-to-sequence (wrapped-stream)
+    (let ((out-stream (salza2:make-compressing-stream 'salza2:gzip-compressor wrapped-stream)))
+      (write-byte 1 out-stream)
+      (close out-stream)
+      (fail (write-byte 2 out-stream) 'salza2:stream-closed-error))))


### PR DESCRIPTION
Uses trivial gray streams to wrap another stream and transparently compress data written to it.

Feel free to leave out the commit that adds a test system if you don't want it.