### PR TITLE
Added macro with-compressing-stream.

### DIFF
--- a/compressor.lisp
+++ b/compressor.lisp
@@ -294,6 +294,10 @@ with OUTPUT, a starting offset, and the count of pending data."
   (reset (bitstream compressor))
   (start-data-format compressor))
 
+(defmacro with-compressing-stream ((type stream output-stream) &body body)
+  `(with-open-stream (,stream (salza2:make-compressing-stream ,type
+                               ,output-stream))
+     ,@body))
 
 (defmacro with-compressor ((var class
                                 &rest initargs

--- a/package.lisp
+++ b/package.lisp
@@ -61,4 +61,5 @@
    #:compress-data
    ;; stream
    #:make-compressing-stream
+   #:with-compressing-stream
    #:stream-closed-error))


### PR DESCRIPTION
This macro gives salza2 a similar stream api to lzlib.
It's useful when you need to pass a compressing stream to other libs like archive.

```
(salza2:with-compressing-stream (:gzip compressor out)
  (let ((archive (archive:open-archive 'archive:tar-archive compressor :direction :output)))
    (dolist (file files (archive:finalize-archive archive))
      (let ((entry (archive:create-entry-from-pathname archive file)))
	(archive:write-entry-to-archive archive entry)))))
```