### PR TITLE
Fix missing dependencies, as found by breakage with POIU.

### DIFF
--- a/salza2.asd
+++ b/salza2.asd
@@ -41,7 +41,8 @@
                       :depends-on ("package"))
                (:file "types"
                       :depends-on ("package"
-                                   "specials"))
+                                   "specials"
+                                   "types"))
                (:file "checksum"
                       :depends-on ("package"
                                    "reset"))
@@ -53,10 +54,11 @@
                                    "types"))
                (:file "chains"
                       :depends-on ("package"
-                                   "specials"))
+                                   "types"))
                (:file "bitstream"
                       :depends-on ("package"
                                    "specials"
+                                   "types"
                                    "reset"))
                (:file "matches"
                       :depends-on ("package"


### PR DESCRIPTION
chains and bitstream need depend on types.

Many other components need not directly depend on package, but were left unchanged.

This is a rebase of #1 on top of 2.1. #1 couldn't be updated because it is based on a defunct repository fork.